### PR TITLE
Change period to underline in counterbalance entry

### DIFF
--- a/CounterBalances/Counterbalance.ts
+++ b/CounterBalances/Counterbalance.ts
@@ -9,11 +9,11 @@ export namespace Counterbalance {
 	export type Entry = typeof Entry.values[number]
 	export namespace Entry {
 		export const values = [
-			...Card.Stack.stacks.flatMap(s => [`fee.${s}`, `settle.${s}`] as const),
-			...Supplier.names.flatMap(s => [`incoming.${s}`, `outgoing.${s}`] as const),
-			`incoming.internal`,
-			`outgoing.internal`,
-			"fee.other",
+			...Card.Stack.stacks.flatMap(s => [`fee_${s}`, `settle_${s}`] as const),
+			...Supplier.names.flatMap(s => [`incoming_${s}`, `outgoing_${s}`] as const),
+			`incoming_internal`,
+			`outgoing_internal`,
+			"fee_other",
 		] as const
 		export const type = isly.string(Entry.values)
 		export const is = type.is

--- a/CounterBalances/index.spec.ts
+++ b/CounterBalances/index.spec.ts
@@ -2,30 +2,30 @@ import { pax2pay } from "../index"
 
 describe("Counterbalances", () => {
 	it("Counterbalances.Counterbalance.add", () => {
-		const Counterbalance1: pax2pay.Counterbalances.Counterbalance = { "fee.other": 123 }
-		const Counterbalance2: pax2pay.Counterbalances.Counterbalance = { "fee.other": 123, "incoming.internal": 789 }
+		const Counterbalance1: pax2pay.Counterbalances.Counterbalance = { fee_other: 123 }
+		const Counterbalance2: pax2pay.Counterbalances.Counterbalance = { fee_other: 123, incoming_internal: 789 }
 		expect(pax2pay.Counterbalances.Counterbalance.add(Counterbalance1, Counterbalance2, "USD")).toEqual({
-			"fee.other": 246,
-			"incoming.internal": 789,
+			fee_other: 246,
+			incoming_internal: 789,
 		})
 	})
 	it("Counterbalances.add", () => {
 		const Counterbalances1: pax2pay.Counterbalances = {
-			USD: { "fee.other": 123 },
-			GBP: { "settle.uk-tpl-marqeta": 999 },
-			SEK: { "settle.uk-tpl-marqeta": 999 },
+			USD: { fee_other: 123 },
+			GBP: { "settle_uk-tpl-marqeta": 999 },
+			SEK: { "settle_uk-tpl-marqeta": 999 },
 		}
-		const Counterbalances2: pax2pay.Counterbalances = { USD: { "fee.other": 123, "incoming.internal": 789 } }
+		const Counterbalances2: pax2pay.Counterbalances = { USD: { fee_other: 123, incoming_internal: 789 } }
 		expect(pax2pay.Counterbalances.add(Counterbalances1, Counterbalances2)).toEqual({
 			USD: {
-				"fee.other": 246,
-				"incoming.internal": 789,
+				fee_other: 246,
+				incoming_internal: 789,
 			},
 			GBP: {
-				"settle.uk-tpl-marqeta": 999,
+				"settle_uk-tpl-marqeta": 999,
 			},
 			SEK: {
-				"settle.uk-tpl-marqeta": 999,
+				"settle_uk-tpl-marqeta": 999,
 			},
 		})
 	})


### PR DESCRIPTION
BigQuery won't allow periods in column names and remapping the properties in analytics would be a pain.