### PR TITLE
Add message id to invite

### DIFF
--- a/User/index.ts
+++ b/User/index.ts
@@ -37,6 +37,7 @@ export namespace User {
 		id: string
 		email: string
 		access: Access
+		messageId?: string
 	}
 	export namespace Invite {
 		export type Creatable = zod.infer<typeof Creatable.typeZod>


### PR DESCRIPTION
Add `messageId` on user invite.
This way we can see if the status of the invite in cloudflare activity logs.

<img width="1569" height="431" alt="image" src="https://github.com/user-attachments/assets/fff9e18c-bad4-48f7-b842-1c2d9ff10593" />


