### PR TITLE
Fix MCCPolicies.update.

### DIFF
--- a/Client/MCCPolicies.ts
+++ b/Client/MCCPolicies.ts
@@ -8,7 +8,7 @@ export class MCCPolicies {
 	async create(policy: MCCPolicy.Creatable): Promise<MCCPolicy | gracely.Error> {
 		return this.client.post<MCCPolicy>(`/mcc-policy`, policy)
 	}
-	async update(id: string, policy: MCCPolicy.Updatable): Promise<MCCPolicy | gracely.Error> {
+	async update(policy: MCCPolicy.Updatable): Promise<MCCPolicy | gracely.Error> {
 		return this.client.put<MCCPolicy>(`/mcc-policy`, policy)
 	}
 	async list(filter: { organization?: string; stack?: Card.Stack }): Promise<MCCPolicy[] | gracely.Error> {

--- a/Client/MCCPolicies.ts
+++ b/Client/MCCPolicies.ts
@@ -8,8 +8,8 @@ export class MCCPolicies {
 	async create(policy: MCCPolicy.Creatable): Promise<MCCPolicy | gracely.Error> {
 		return this.client.post<MCCPolicy>(`/mcc-policy`, policy)
 	}
-	async update(id: string, policy: MCCPolicy.Creatable): Promise<MCCPolicy | gracely.Error> {
-		return this.client.put<MCCPolicy>(`/mcc-policy/${id}`, policy)
+	async update(id: string, policy: MCCPolicy.Updatable): Promise<MCCPolicy | gracely.Error> {
+		return this.client.put<MCCPolicy>(`/mcc-policy`, policy)
 	}
 	async list(filter: { organization?: string; stack?: Card.Stack }): Promise<MCCPolicy[] | gracely.Error> {
 		const query = Object.entries(filter)


### PR DESCRIPTION
`id` is included in the body in the update call: [update endpoint](https://github.com/pax2pay/worker-banking-ledger/blob/master/mcc-policy/update.ts)